### PR TITLE
meerk-3 If config specified non-existent emoji, status will not change

### DIFF
--- a/meerk/status/SyncException.py
+++ b/meerk/status/SyncException.py
@@ -19,26 +19,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from slackclient import SlackClient
-
-from Status import Status
-from SyncException import SyncException
 
 
-class SlackStatus(Status):
-
-    def __init__(self, sc, text, emoji):
-        # type: (SlackClient, str, str) -> SlackStatus
-        self.sc = sc
-        self.text = text
-        self.emoji = emoji
-
-    def sync(self):
-        # type: () -> None
-        self.sc.api_call(
-            'users.profile.set',
-            profile={
-                'status_text': self.text,
-                'status_emoji': self.emoji
-            }
-        )
+class SyncException(Exception):
+    def __init__(self, *args, **kwargs):
+        Exception.__init__(self, *args, **kwargs)

--- a/meerk/status/__init__.py
+++ b/meerk/status/__init__.py
@@ -23,3 +23,4 @@ from CompositeStatus import CompositeStatus
 from LoggableStatus import LoggableStatus
 from SlackStatus import SlackStatus
 from Status import Status
+from SyncException import SyncException


### PR DESCRIPTION
Add exception throwing if slack emoji does not correct